### PR TITLE
chore(plugin): to support Webpack 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react2amp",
-  "version": "1.19.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react2amp",
-  "version": "1.19.1",
+  "version": "5.0.0",
   "description": "",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
## What is the current behavior?
Using the latest Webpack@5.11.1 to build our project, there are some build error when we attempt to use `webpackPluginAmpAssets` plugin for CSS and JS extraction since there are some breaking change including the infrastructure and data structure change in webpack.

![err-report](https://user-images.githubusercontent.com/13689584/103726552-211c4180-5014-11eb-864f-a391c837e6cb.png)

## Does this PR introduce a breaking change?
Yes

## Implementation Notes
- retire `chunk.getModules()` and use new ChunkGraph API
- add a new module called `CssModule` case for handling css chunk extraction and validate it by the `context`
- retire `module._orderedConcatenationList` and use `module._modules` instead